### PR TITLE
Remove `LearningTask`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DLPipelines"
 uuid = "e6530d7c-7faa-4ede-a0d6-9eff9baad396"
 authors = ["Lorenz Ohly <lorenz.ohly@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 DataLoaders = "2e981812-ef13-4a9c-bfa0-ab13047b12a9"

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -31,7 +31,6 @@ Let's give those concepts variable names and generic types so we can refer to th
 
 |        Concept | Abstract code  | Image classification                                     |
 | -------------: | :------------- | :------------------------------------------------------- |
-|           Task | `Task`         | `ImageClassificationTask <: Task`                        |
 |         Method | `Method{Task}` | `ImageClassification <: Method{ImageClassificationTask}` |
 |          Input | `input::I`     | `image::AbstractMatrix{<:Colorant}`                      |
 |         Target | `target::T`    | `category::String`                                       |
@@ -41,7 +40,7 @@ Let's give those concepts variable names and generic types so we can refer to th
 
 So a `Task` is an abstract type representing a mapping from some input type `I` to target type `T`. A `Method{T}` implements the task `T` by using encoded representations `X` and `Y`. For example, the `ImageClassificationTask` task represents a mapping from an image to a category. The concrete [`LearningMethod`](#) `ImageClassification` implements that task using the encoded representations defined in the table above.
 
-The most important type is [`LearningMethod`](#) which represents a method for a [`LearningTask`](#). All interface functions will dispatch on `LearningMethod`. It should be a concrete `struct` containing necessary configuration. 
+The most important type is [`LearningMethod`](#) which represents a method for a learning task. All interface functions will dispatch on `LearningMethod`. It should be a concrete `struct` containing necessary configuration. 
 
 ## Core pipelines
 

--- a/src/task.jl
+++ b/src/task.jl
@@ -87,8 +87,13 @@ pass them to [`encodeinput`](#) and [`encodetarget`](#).
   tuple of `(input, target)`, for example a `Dict` that includes additional
   information. `encode` still needs to return an `(x, y)`-tuple, though.
 """
-encode(method, context, (input, target)::Union{Tuple, NamedTuple}) =
-    (encodeinput(method, context, input), encodetarget(method, context, target))
+function encode(method, context, sample)
+    (input, target) = sample
+    return (
+        encodeinput(method, context, input),
+        encodetarget(method, context, target)
+    )
+end
 
 
 """

--- a/src/task.jl
+++ b/src/task.jl
@@ -3,29 +3,18 @@
 # # Types
 #
 # We start off by defining the abstract types that will be used for dispatch.
-# ### [`LearningTask`](#)
-"""
-    abstract type LearningTask
-
-Represents a mapping from high-level types
-`I` to `T`.
-
-See also [`LearningMethod`](#).
-"""
-abstract type LearningTask end
 
 
 # ### [`LearningMethod`](#)
 """
-    abstract type LearningMethod{LearningTask}
+    abstract type LearningMethod
 
-Represents a concrete approach for solving a
-[`LearningTask`](#).
+Represents a concrete approach for solving a learning task.
 
 See [core interface](../docs/interfaces/core.md) for more on
 how to implement custom `LearningMethod`s
 """
-abstract type LearningMethod{LearningTask} end
+abstract type LearningMethod end
 
 
 # ### [`Context`](#) and concrete types


### PR DESCRIPTION
Since in practice I have found little benefit to `DLPipelines.LearningTask`s over just abstract `LearningMethod` they are being removed to get rid of unneeded complexity.